### PR TITLE
fix: 정석으로 계산 진행 시 기간 입력에서 발생하는 오류 수정

### DIFF
--- a/FrontEnd/src/component/ValueInput.js
+++ b/FrontEnd/src/component/ValueInput.js
@@ -22,7 +22,7 @@ const ValueInput = () => {
         startDate:date,
     }));
 
-      if (date > endDate) {
+      if (date > endDate && endDate !== null) {
         setEndDate(null);
         alert("종료 일자가 시작 일자보다 앞에 올 수 없습니다.");
       };
@@ -132,13 +132,13 @@ ${MinAreaValue}보다 큰 숫자여야 합니다.`);
 
     // DatePicker의 input박스 수정
     const CustomInputStart = forwardRef(({value, onClick}, ref) => (
-        <button className="customInput" onClick={onClick} ref={ref}>
+        <button type="button" className="customInput" onClick={onClick} ref={ref}>
             {value || "시작 일자"}
         </button>
     ));
 
     const CustomInputEnd = forwardRef(({value, onClick}, ref) => (
-        <button className="customInput" onClick={onClick} ref={ref}>
+        <button type="button" className="customInput" onClick={onClick} ref={ref}>
             {value || "종료 일자"}
         </button>
     ));


### PR DESCRIPTION
지역부터 면적까지 입력 후 기간을 클릭하면 바로 계산 페이지로 넘어가는 오류 발생
-> 기간의 button태그에 type button을 한번 더 지정해서 submit이 아닌 button임을 정확히 설정하여 오류 해결